### PR TITLE
Tests for GithubCommands module

### DIFF
--- a/lib/slax/commands/github_commands.ex
+++ b/lib/slax/commands/github_commands.ex
@@ -37,9 +37,10 @@ defmodule Slax.Commands.GithubCommands do
   @doc """
   Pulls all issue templates from a story repo that are included in `story_paths`.
   It  then uses these templates to create issues in a newly created github repository,
+  If there is no github repository the function will exit early
   """
   def create_reusable_stories(
-        %{project_name: project_name} = results,
+        %{project_name: project_name, github_repo: _} = results,
         github_access_token,
         org_name,
         story_repo,
@@ -84,6 +85,8 @@ defmodule Slax.Commands.GithubCommands do
         Map.update(results, :errors, %{}, fn x -> Map.put(x, :reusable_stories, message) end)
     end
   end
+
+  def create_reusable_stories(results, _, _, _, _), do: results
 
   defp process_tree(data, story_repo, story_paths, github_access_token) do
     Map.get(data, "tree", [])
@@ -149,7 +152,7 @@ defmodule Slax.Commands.GithubCommands do
     end)
     |> Enum.split_with(fn
       {:ok, _, _} -> true
-      {:error, _,_} -> false
+      {:error, _, _} -> false
     end)
   end
 

--- a/lib/slax/commands/github_commands.ex
+++ b/lib/slax/commands/github_commands.ex
@@ -15,6 +15,12 @@ defmodule Slax.Commands.GithubCommands do
 
   alias Slax.{Github}
 
+  @doc """
+  Accepts a results map and the potential name of a new github repo.
+  If the name is a valid github repo name, it will return a new result map
+  containing the `project_name` as well as a key indicating that the `project_name`
+  step is complete
+  """
   def parse_project_name(results, text) do
     case Regex.run(~r/^[a-zA-Z0-9\-_]{3,21}$/, text) do
       [project_name] ->
@@ -28,6 +34,10 @@ defmodule Slax.Commands.GithubCommands do
     end
   end
 
+  @doc """
+  Pulls all issue templates from a story repo that are included in `story_paths`.
+  It  then uses these templates to create issues in a newly created github repository,
+  """
   def create_reusable_stories(
         %{project_name: project_name} = results,
         github_access_token,

--- a/lib/slax/commands/github_commands.ex
+++ b/lib/slax/commands/github_commands.ex
@@ -71,7 +71,7 @@ defmodule Slax.Commands.GithubCommands do
         results
 
       {:error, message} ->
-        Map.update(results, :errors, %{}, fn x -> Map.put(x, :resuseable_stories, message) end)
+        Map.update(results, :errors, %{}, fn x -> Map.put(x, :reusable_stories, message) end)
     end
   end
 
@@ -102,7 +102,7 @@ defmodule Slax.Commands.GithubCommands do
     blobs
     |> Enum.map(fn {:ok, path, content} ->
       with {:ok, issue} <- Base.decode64(content |> String.replace("\n", "")),
-           {:ok, front_matter, body} <- YamlFrontMatter.parse(issue) do
+           {:ok, {:ok, front_matter}, body} <- YamlFrontMatter.parse(issue) do
         {:ok, path, front_matter, body}
       else
         :error ->
@@ -139,7 +139,7 @@ defmodule Slax.Commands.GithubCommands do
     end)
     |> Enum.split_with(fn
       {:ok, _, _} -> true
-      {:error, _} -> false
+      {:error, _,_} -> false
     end)
   end
 

--- a/lib/slax/commands/github_commands.ex
+++ b/lib/slax/commands/github_commands.ex
@@ -10,7 +10,7 @@ defmodule Slax.Commands.GithubCommands do
     :slack_channel,
     :lintron,
     :board_checker,
-    :resuseable_stories
+    :reusable_stories
   ]
 
   alias Slax.{Github}
@@ -53,7 +53,7 @@ defmodule Slax.Commands.GithubCommands do
               Enum.map(errors, fn {:error, path, message} -> "#{path}: #{message}" end)
               |> Enum.join("\n")
 
-            Map.update(results, :errors, %{}, fn x -> Map.put(x, :resuseable_stories, errors) end)
+            Map.update(results, :errors, %{}, fn x -> Map.put(x, :reusable_stories, errors) end)
           else
             results
           end
@@ -62,7 +62,7 @@ defmodule Slax.Commands.GithubCommands do
           if length(issue_ids) > 0 do
             Map.put(results, :reusable_stories, true)
             |> Map.update(:success, %{}, fn x ->
-              Map.put(x, :resuseable_stories, "Reuseable Stories Created")
+              Map.put(x, :reusable_stories, "Reuseable Stories Created")
             end)
           else
             results
@@ -186,8 +186,8 @@ defmodule Slax.Commands.GithubCommands do
       :board_checker ->
         "Board Checker"
 
-      :resuseable_stories ->
-        "Reuseable Stories"
+      :reusable_stories ->
+        "Reusable Stories"
 
       _ ->
         ""

--- a/test/slax/commands/github_commands_test.exs
+++ b/test/slax/commands/github_commands_test.exs
@@ -1,11 +1,11 @@
 defmodule Slax.GithubCommands.Test do
   use Slax.ModelCase, async: true
-  alias Slax.Commands.GithubCommands
   import Mox
+  @subject Slax.Commands.GithubCommands
 
   describe "format_issues/1" do
     test "when there is an 'in progress' label" do
-      assert GithubCommands.format_issues([
+      assert @subject.format_issues([
                %{
                  "title" => "title",
                  "updated_at" => "2019-04-18T14:08:35Z",
@@ -15,7 +15,7 @@ defmodule Slax.GithubCommands.Test do
     end
 
     test "when there is not an 'in progress' label" do
-      assert GithubCommands.format_issues([
+      assert @subject.format_issues([
                %{
                  "title" => "title",
                  "updated_at" => "2019-04-18T14:08:35Z",
@@ -45,7 +45,7 @@ defmodule Slax.GithubCommands.Test do
     end
 
     test "when there are no errors for any steps", %{starting_result: starting_result} do
-      result = GithubCommands.format_results(starting_result)
+      result = @subject.format_results(starting_result)
 
       assert result ==
                "Project Name: project_name\nGithub: org_name/project_name\nGithub Teams: \nSlack: slack_channel\nLintron: \nBoard Checker: \nReusable Stories: "
@@ -64,7 +64,7 @@ defmodule Slax.GithubCommands.Test do
         }
       }
 
-      result = GithubCommands.format_results(starting_result)
+      result = @subject.format_results(starting_result)
 
       assert result ==
                "Project Name: project_name\nGithub: org_name/project_name\nGithub Teams: \nSlack: slack_channel error\nLintron: \nBoard Checker: \nReusable Stories: "
@@ -81,7 +81,7 @@ defmodule Slax.GithubCommands.Test do
     setup :setup_starting_result
 
     test "invalid characters", %{starting_result: starting_result} do
-      with result <- GithubCommands.parse_project_name(starting_result, "hi&") do
+      with result <- @subject.parse_project_name(starting_result, "hi&") do
         assert Map.get(result, :errors) == %{project_name: "Invalid Project Name"}
         assert Map.get(result, :project_name) == nil
       end
@@ -89,7 +89,7 @@ defmodule Slax.GithubCommands.Test do
 
     test "too many characters", %{starting_result: starting_result} do
       with result <-
-             GithubCommands.parse_project_name(
+             @subject.parse_project_name(
                starting_result,
                "thisshouldbemorethantwentytwocharacters"
              ) do
@@ -99,7 +99,7 @@ defmodule Slax.GithubCommands.Test do
     end
 
     test "valid_input", %{starting_result: starting_result} do
-      with result <- GithubCommands.parse_project_name(starting_result, "valid_repo_name") do
+      with result <- @subject.parse_project_name(starting_result, "valid_repo_name") do
         assert Map.get(result, :errors) == %{}
         assert Map.get(result, :success) == %{project_name: "Project Name Parsed"}
         assert Map.get(result, :project_name) == "valid_repo_name"
@@ -166,7 +166,7 @@ defmodule Slax.GithubCommands.Test do
       expect(Slax.HttpMock, :post, 3, &successful_issue_request/4)
 
       result =
-        GithubCommands.create_reusable_stories(
+        @subject.create_reusable_stories(
           starting_result,
           "access_token",
           "test_org",
@@ -197,7 +197,7 @@ defmodule Slax.GithubCommands.Test do
       expect(Slax.HttpMock, :get, 1, &failing_request/3)
 
       result =
-        GithubCommands.create_reusable_stories(
+        @subject.create_reusable_stories(
           starting_result,
           "access_token",
           "test_org",
@@ -217,7 +217,7 @@ defmodule Slax.GithubCommands.Test do
       expect(Slax.HttpMock, :get, 2, &failing_request/3)
 
       result =
-        GithubCommands.create_reusable_stories(
+        @subject.create_reusable_stories(
           starting_result,
           "access_token",
           "test_org",
@@ -243,7 +243,7 @@ defmodule Slax.GithubCommands.Test do
       expect(Slax.HttpMock, :post, 3, &failing_request/4)
 
       result =
-        GithubCommands.create_reusable_stories(
+        @subject.create_reusable_stories(
           starting_result,
           "access_token",
           "test_org",
@@ -279,7 +279,7 @@ defmodule Slax.GithubCommands.Test do
       expect(Slax.HttpMock, :post, 3, &successful_issue_request/4)
 
       result =
-        GithubCommands.create_reusable_stories(
+        @subject.create_reusable_stories(
           starting_result,
           "access_token",
           "test_org",
@@ -315,7 +315,7 @@ defmodule Slax.GithubCommands.Test do
       expect(Slax.HttpMock, :post, 3, &successful_issue_request/4)
 
       result =
-        GithubCommands.create_reusable_stories(
+        @subject.create_reusable_stories(
           starting_result,
           "access_token",
           "test_org",

--- a/test/slax/commands/github_commands_test.exs
+++ b/test/slax/commands/github_commands_test.exs
@@ -3,28 +3,6 @@ defmodule Slax.GithubCommands.Test do
   import Mox
   @subject Slax.Commands.GithubCommands
 
-  describe "format_issues/1" do
-    test "when there is an 'in progress' label" do
-      assert @subject.format_issues([
-               %{
-                 "title" => "title",
-                 "updated_at" => "2019-04-18T14:08:35Z",
-                 "labels" => [%{"name" => "in progress"}]
-               }
-             ]) =~ "Last Updated at"
-    end
-
-    test "when there is not an 'in progress' label" do
-      assert @subject.format_issues([
-               %{
-                 "title" => "title",
-                 "updated_at" => "2019-04-18T14:08:35Z",
-                 "labels" => [%{"name" => "back log"}]
-               }
-             ]) =~ ":snail: *Issues In Progress for"
-    end
-  end
-
   describe "format_results/1" do
     setup :setup_no_errors
 

--- a/test/slax/commands/github_commands_test.exs
+++ b/test/slax/commands/github_commands_test.exs
@@ -112,7 +112,10 @@ defmodule Slax.GithubCommands.Test do
      context
      |> Map.put(:starting_result, %{errors: %{}, success: %{}})
      |> put_in([:starting_result, :success, :project_name], "Project Name Parsed")
-     |> put_in([:starting_result, :project_name], "valid_project_name")}
+     |> put_in([:starting_result, :project_name], "valid_project_name")
+     |> put_in([:starting_result, :github_repo], "repo_url")
+     |> put_in([:starting_result, :success, :github_repo], "Github Repo Found or Created: <repo_url>")
+    }
   end
 
   def successful_tree_request(_, _, _) do
@@ -177,8 +180,13 @@ defmodule Slax.GithubCommands.Test do
 
       assert result[:errors] == %{}
       assert result[:project_name] == "valid_project_name"
+      assert result[:github_repo] == "repo_url"
       assert result[:reusable_stories] == true
-      assert result[:success][:reusable_stories] == "Reuseable Stories Created"
+      assert result[:success] == %{
+        project_name: "Project Name Parsed",
+        reusable_stories: "Reuseable Stories Created",
+        github_repo: "Github Repo Found or Created: <repo_url>"
+      }
     end
 
     def failing_request(_, _, _) do
@@ -189,6 +197,29 @@ defmodule Slax.GithubCommands.Test do
            "message": "you done goofed"
          }>
        }}
+    end
+
+    test "when the starting results dont have a github repo" do
+      starting_result =
+        %{
+          project_name: "valid_project_name",
+          errors: %{},
+          success: %{
+            project_name: "Project Name Parsed"
+          }
+        }
+
+      result =
+        @subject.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result == starting_result
     end
 
     def failing_request(w, x, y, _), do: failing_request(w, x, y)
@@ -206,10 +237,14 @@ defmodule Slax.GithubCommands.Test do
           path3: "story_path3"
         )
 
-      assert result[:reusable_stories] == nil
       assert result[:errors] == %{reusable_stories: "you done goofed"}
       assert result[:project_name] == "valid_project_name"
-      assert result[:success] == %{project_name: "Project Name Parsed"}
+      assert result[:github_repo] == "repo_url"
+      assert result[:reusable_stories] == nil
+      assert result[:success] == %{
+        project_name: "Project Name Parsed",
+        github_repo: "Github Repo Found or Created: <repo_url>"
+      }
     end
 
     test "when fetching a blob fails", %{starting_result: starting_result} do
@@ -226,15 +261,18 @@ defmodule Slax.GithubCommands.Test do
           path3: "story_path3"
         )
 
-      assert result[:reusable_stories] == nil
-
       assert result[:errors] == %{
-               reusable_stories:
-                 "story_path1.md: you done goofed\nstory_path3.md: you done goofed"
-             }
-
+        reusable_stories:
+        "story_path1.md: you done goofed\nstory_path3.md: you done goofed"
+      }
       assert result[:project_name] == "valid_project_name"
-      assert result[:success] == %{project_name: "Project Name Parsed"}
+      assert result[:github_repo] == "repo_url"
+      assert result[:reusable_stories] == nil
+      assert result[:success] == %{
+        project_name: "Project Name Parsed",
+        github_repo: "Github Repo Found or Created: <repo_url>"
+      }
+
     end
 
     test "when posting issues fails", %{starting_result: starting_result} do
@@ -252,15 +290,18 @@ defmodule Slax.GithubCommands.Test do
           path3: "story_path3"
         )
 
-      assert result[:reusable_stories] == nil
-
       assert result[:errors] == %{
-               reusable_stories:
-                 "story_path1.md: you done goofed\nstory_path3.md: you done goofed"
-             }
-
+        reusable_stories:
+        "story_path1.md: you done goofed\nstory_path3.md: you done goofed"
+      }
       assert result[:project_name] == "valid_project_name"
-      assert result[:success] == %{project_name: "Project Name Parsed"}
+      assert result[:github_repo] == "repo_url"
+      assert result[:reusable_stories] == nil
+      assert result[:success] == %{
+        project_name: "Project Name Parsed",
+        github_repo: "Github Repo Found or Created: <repo_url>"
+      }
+
     end
 
     def invalid_blob_request(_, _, _) do
@@ -288,15 +329,17 @@ defmodule Slax.GithubCommands.Test do
           path3: "story_path3"
         )
 
-      assert result[:reusable_stories] == nil
-
       assert result[:errors] == %{
-               reusable_stories:
-                 "story_path1.md: Unable to parse content\nstory_path3.md: Unable to parse content"
-             }
-
+        reusable_stories:
+        "story_path1.md: Unable to parse content\nstory_path3.md: Unable to parse content"
+      }
       assert result[:project_name] == "valid_project_name"
-      assert result[:success] == %{project_name: "Project Name Parsed"}
+      assert result[:github_repo] == "repo_url"
+      assert result[:reusable_stories] == nil
+      assert result[:success] == %{
+        project_name: "Project Name Parsed",
+        github_repo: "Github Repo Found or Created: <repo_url>"
+      }
     end
 
     def invalid_frontmatter_request(_, _, _) do
@@ -324,15 +367,17 @@ defmodule Slax.GithubCommands.Test do
           path3: "story_path3"
         )
 
-      assert result[:reusable_stories] == nil
-
       assert result[:errors] == %{
-               reusable_stories:
-                 "story_path1.md: invalid_front_matter\nstory_path3.md: invalid_front_matter"
-             }
-
+        reusable_stories:
+        "story_path1.md: invalid_front_matter\nstory_path3.md: invalid_front_matter"
+      }
       assert result[:project_name] == "valid_project_name"
-      assert result[:success] == %{project_name: "Project Name Parsed"}
+      assert result[:github_repo] == "repo_url"
+      assert result[:reusable_stories] == nil
+      assert result[:success] == %{
+        project_name: "Project Name Parsed",
+        github_repo: "Github Repo Found or Created: <repo_url>"
+      }
     end
   end
 end

--- a/test/slax/commands/github_commands_test.exs
+++ b/test/slax/commands/github_commands_test.exs
@@ -1,0 +1,288 @@
+defmodule Slax.GithubCommands.Test do
+  use Slax.ModelCase, async: true
+  alias Slax.Commands.GithubCommands
+  import Mox
+
+  test "format_issues/1" do
+    assert GithubCommands.format_issues([
+             %{
+               "title" => "title",
+               "updated_at" => "2019-04-18T14:08:35Z",
+               "labels" => [%{"name" => "in progress"}]
+             }
+           ]) =~ "Last Updated at"
+  end
+
+  describe "parse_project_name/2" do
+    def setup_starting_result(context) do
+      {:ok,
+       context
+       |> Map.put(:starting_result, %{errors: %{}, success: %{}})}
+    end
+
+    setup :setup_starting_result
+
+    test "invalid characters", %{starting_result: starting_result} do
+      with result <- GithubCommands.parse_project_name(starting_result, "hi&") do
+        assert Map.get(result, :errors) == %{project_name: "Invalid Project Name"}
+        assert Map.get(result, :project_name) == nil
+      end
+    end
+
+    test "too many characters", %{starting_result: starting_result} do
+      with result <-
+             GithubCommands.parse_project_name(
+               starting_result,
+               "thisshouldbemorethantwentytwocharacters"
+             ) do
+        assert Map.get(result, :errors) == %{project_name: "Invalid Project Name"}
+        assert Map.get(result, :project_name) == nil
+      end
+    end
+
+    test "valid_input", %{starting_result: starting_result} do
+      with result <- GithubCommands.parse_project_name(starting_result, "valid_repo_name") do
+        assert Map.get(result, :errors) == %{}
+        assert Map.get(result, :success) == %{project_name: "Project Name Parsed"}
+        assert Map.get(result, :project_name) == "valid_repo_name"
+      end
+    end
+  end
+
+  def setup_starting_result_with_name(context) do
+    {:ok,
+     context
+     |> Map.put(:starting_result, %{errors: %{}, success: %{}})
+     |> put_in([:starting_result, :success, :project_name], "Project Name Parsed")
+     |> put_in([:starting_result, :project_name], "valid_project_name")}
+  end
+
+  def setup_successful_tree_requests(context) do
+    {:ok,
+     context
+     |> Map.put(:starting_result, %{errors: %{}, success: %{}})
+     |> put_in([:starting_result, :success, :project_name], "Project Name Parsed")
+     |> put_in([:starting_result, :project_name], "valid_project_name")}
+  end
+
+  def successful_tree_request(_, _, _) do
+    {:ok,
+     %HTTPoison.Response{
+       status_code: 200,
+       body: ~s<{
+             "tree": [
+               {
+                 "path": "story_path1.md",
+                 "sha": "test_sha",
+                 "type": "blob"
+               },
+               {
+                 "path": "story_path3.md",
+                 "sha": "test_sha",
+                 "type": "blob"
+               }
+
+             ]
+           }>
+     }}
+  end
+
+  def successful_blob_request(_, _, _) do
+    {:ok,
+     %HTTPoison.Response{
+       status_code: 200,
+       body: ~s<{
+           "content": "LS0tCnRpdGxlOiB0ZXN0X3RpdGxlCi0tLQp0ZXN0IGNvbnRlbnQK"
+         }>
+     }}
+  end
+
+  def successful_issue_request(_,_,_,_) do
+    {:ok,
+     %HTTPoison.Response{
+       status_code: 200,
+       body: ~s<{
+         "content": ["1"]
+       }>
+     }}
+  end
+
+
+  describe "create_reusable_stories/5" do
+    setup [:setup_starting_result_with_name]
+
+    test "when all requests are successful", %{starting_result: starting_result} do
+      expect(Slax.HttpMock, :get, 1, &successful_tree_request/3)
+      expect(Slax.HttpMock, :get, 2, &successful_blob_request/3)
+      expect(Slax.HttpMock, :post, 3, &successful_issue_request/4)
+
+      result =
+        GithubCommands.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result[:errors] == %{}
+      assert result[:project_name] == "valid_project_name"
+      assert result[:reusable_stories] == true
+      assert result[:success][:reusable_stories] == "Reuseable Stories Created"
+    end
+
+    def failing_request(_,_,_) do
+      {:ok,
+       %HTTPoison.Response{
+         status_code: 400,
+         body: ~s<{
+           "message": "you done goofed"
+         }>
+       }}
+    end
+    def failing_request(w,x,y,_), do: failing_request(w,x,y)
+
+    test "when fetching the project tree fails", %{starting_result: starting_result} do
+      expect(Slax.HttpMock, :get, 1, &failing_request/3)
+
+      result =
+        GithubCommands.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result[:reusable_stories] == nil
+      assert result[:errors] == %{reusable_stories: "you done goofed"}
+      assert result[:project_name] == "valid_project_name"
+      assert result[:success] == %{project_name: "Project Name Parsed"}
+    end
+
+    test "when fetching a blob fails", %{starting_result: starting_result} do
+      expect(Slax.HttpMock, :get, 1, &successful_tree_request/3)
+      expect(Slax.HttpMock, :get, 2, &failing_request/3)
+
+      result =
+        GithubCommands.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result[:reusable_stories] == nil
+
+      assert result[:errors] == %{
+               reusable_stories:
+                 "story_path1.md: you done goofed\nstory_path3.md: you done goofed"
+             }
+
+      assert result[:project_name] == "valid_project_name"
+      assert result[:success] == %{project_name: "Project Name Parsed"}
+    end
+
+    test "when posting issues fails", %{starting_result: starting_result} do
+      expect(Slax.HttpMock, :get, 1, &successful_tree_request/3)
+      expect(Slax.HttpMock, :get, 2, &successful_blob_request/3)
+      expect(Slax.HttpMock, :post, 3, &failing_request/4)
+
+      result =
+        GithubCommands.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result[:reusable_stories] == nil
+
+      assert result[:errors] == %{
+        reusable_stories:
+        "story_path1.md: you done goofed\nstory_path3.md: you done goofed"
+      }
+
+      assert result[:project_name] == "valid_project_name"
+      assert result[:success] == %{project_name: "Project Name Parsed"}
+    end
+
+    def invalid_blob_request(_,_,_) do
+      {:ok,
+       %HTTPoison.Response{
+         status_code: 200,
+         body: ~s<{
+           "content": "invalidblob"
+         }>
+       }}
+    end
+
+    test "when decoding a blob fails", %{starting_result: starting_result} do
+      expect(Slax.HttpMock, :get, 1, &successful_tree_request/3)
+      expect(Slax.HttpMock, :get, 2, &invalid_blob_request/3)
+      expect(Slax.HttpMock, :post, 3, &successful_issue_request/4)
+
+      result =
+        GithubCommands.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result[:reusable_stories] == nil
+
+      assert result[:errors] == %{
+        reusable_stories:
+        "story_path1.md: Unable to parse content\nstory_path3.md: Unable to parse content"
+      }
+
+      assert result[:project_name] == "valid_project_name"
+      assert result[:success] == %{project_name: "Project Name Parsed"}
+    end
+
+    def invalid_frontmatter_request(_,_,_) do
+      {:ok,
+       %HTTPoison.Response{
+         status_code: 200,
+         body: ~s<{
+           "content": "LS0KaW52YWxpZCBmcm9udG1hdHRlcgpfCm9vcHMK"
+         }>
+       }}
+    end
+
+    test "when parsing issue frontmatter fails", %{starting_result: starting_result} do
+      expect(Slax.HttpMock, :get, 1, &successful_tree_request/3)
+      expect(Slax.HttpMock, :get, 2, &invalid_frontmatter_request/3)
+      expect(Slax.HttpMock, :post, 3, &successful_issue_request/4)
+
+      result =
+        GithubCommands.create_reusable_stories(
+          starting_result,
+          "access_token",
+          "test_org",
+          "story_repo",
+          path1: "story_path1",
+          path3: "story_path3"
+        )
+
+      assert result[:reusable_stories] == nil
+
+      assert result[:errors] == %{
+        reusable_stories:
+        "story_path1.md: invalid_front_matter\nstory_path3.md: invalid_front_matter"
+      }
+
+      assert result[:project_name] == "valid_project_name"
+      assert result[:success] == %{project_name: "Project Name Parsed"}
+    end
+  end
+end

--- a/test/slax/commands/github_commands_test.exs
+++ b/test/slax/commands/github_commands_test.exs
@@ -21,7 +21,7 @@ defmodule Slax.GithubCommands.Test do
                  "updated_at" => "2019-04-18T14:08:35Z",
                  "labels" => [%{"name" => "back log"}]
                }
-             ]) =~ ":snail: *Issues In Progress for 5/18* :snail: \n"
+             ]) =~ ":snail: *Issues In Progress for"
     end
   end
 


### PR DESCRIPTION
Connected to  #48, according to my coveralls this puts coverage at 57%

Also fixes a couple bugs in the module which I will leave comments next to
I took the liberty of trying to converge on a common spelling of `reusable` if there is a preferred alternate spelling let me know and I can rename.

If this is too hefty I can split out into separate PRs as well!