### PR TITLE
Tests for NewProject module

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,7 @@ config :logger, :console,
   metadata: [:request_id]
 
 config :slax, http_adapter: HTTPoison
+config :slax, github_commands: Slax.Commands.GithubCommands
 
 config :slax, :lintron,
   secret: System.get_env("LINTRON_SECRET"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,7 @@ config :slax, SlaxWeb.Endpoint,
 config :logger, level: :warn
 
 config :slax, http_adapter: Slax.HttpMock
+config :slax, github_commands: Slax.Commands.GithubCommandsMock
 
 # Configure your database
 config :slax, Slax.Repo,

--- a/lib/slax/commands/github_commands/behaviour.ex
+++ b/lib/slax/commands/github_commands/behaviour.ex
@@ -1,0 +1,12 @@
+defmodule Slax.Commands.GithubCommands.Behaviour do
+  @typep results :: map()
+  @typep github_access_token :: String.t()
+  @typep org_name :: String.t()
+  @typep story_repo :: String.t()
+  @typep project_name :: String.t()
+  @typep story_paths :: [String.t()]
+
+  @callback create_reusable_stories(results, github_access_token, org_name, story_repo, story_paths) :: results
+
+  @callback parse_project_name(results, project_name) :: results
+end

--- a/lib/slax/commands/project.ex
+++ b/lib/slax/commands/project.ex
@@ -3,7 +3,6 @@ defmodule Slax.Commands.NewProject do
   Automates creation of a new project
   """
   alias Slax.{Github, Slack}
-  alias Slax.Commands.GithubCommands
 
   @doc """
   Automates creating a new project.
@@ -35,10 +34,10 @@ defmodule Slax.Commands.NewProject do
   @spec new_project(binary, binary, binary, binary, keyword(binary), binary) :: map
   def new_project(org_name, name, github_access_token, story_repo, story_paths, org_teams) do
     %{errors: %{}, success: %{}}
-    |> GithubCommands.parse_project_name(name)
+    |> github_commands().parse_project_name(name)
     |> create_github_repo(github_access_token, org_name)
     |> create_slack_channel
-    |> GithubCommands.create_reusable_stories(
+    |> github_commands().create_reusable_stories(
       github_access_token,
       org_name,
       story_repo,
@@ -56,6 +55,8 @@ defmodule Slax.Commands.NewProject do
       "Board Checker Created"
     )
   end
+
+  defp github_commands(), do: Application.get_env(:slax, :github_commands)
 
   defp create_github_repo(%{project_name: project_name} = results, github_access_token, org_name) do
     case Github.find_or_create_repo(%{
@@ -133,6 +134,8 @@ defmodule Slax.Commands.NewProject do
     results
   end
 
+  defp add_org_teams(results, _, _, _), do: results
+
   defp send_org_teams_to_github(repo, teams, github_access_token) do
     teams
     |> String.split([",", " "], trim: true)
@@ -149,7 +152,7 @@ defmodule Slax.Commands.NewProject do
     end)
     |> Enum.split_with(fn
       {:ok, _, _} -> true
-      {:error, _} -> false
+      {:error, _,_} -> false
     end)
   end
 

--- a/test/slax/commands/project_test.exs
+++ b/test/slax/commands/project_test.exs
@@ -1,0 +1,355 @@
+defmodule Slax.Commands.NewProjectTest do
+  use Slax.ModelCase, async: true
+  import Mox
+
+  @subject Slax.Commands.NewProject
+
+  def response(text, status, response) do
+    fn path, _, _ ->
+      assert String.contains?(path, text)
+
+      {:ok,
+       %HTTPoison.Response{
+         status_code: status,
+         body: response
+       }}
+    end
+  end
+
+  def post_response(text, status, response) do
+    fn path, body, _, _ ->
+      assert String.contains?(path, text) || String.contains?(body, text)
+
+      {:ok,
+       %HTTPoison.Response{
+         status_code: status,
+         body: response
+       }}
+    end
+  end
+
+  def successful_create_reusable_stories(results, _,_,_,_) do
+    results
+    |> put_in([:resuseable_stories], true)
+    |> put_in([:success, :resuseable_stories], "Reuseable Stories Created")
+  end
+
+  def failing_create_reusable_stories(results, _,_,_,_), do: results
+
+  describe "new_project/6" do
+    test "when all args are valid and all requests work and the repo hasn't been created yet" do
+      alias Slax.Commands.{GithubCommandsMock, GithubCommands}
+
+      # validate the project_name
+      expect(GithubCommandsMock, :parse_project_name, 1, &GithubCommands.parse_project_name/2)
+
+      # we can't find the repo so it doesn't exist yet
+      expect(
+        Slax.HttpMock,
+        :get,
+        1,
+        response("project_name", 404, ~S<{ "message": "not found" }>)
+      )
+
+      # we create the repo
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response("project_name", 200, ~S<{ "html_url": "project_url" }>)
+      )
+
+      # add all reusable stories from the story_repo
+      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &successful_create_reusable_stories/5)
+
+      # create slack channel
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response(
+          "project_name",
+          200,
+          ~S<{ "ok": true, "channel": { "id": "1", "name": "project_name" } }>
+        )
+      )
+
+      # add the teams push permission to the github repo
+      expect(Slax.HttpMock, :put, 1, post_response("org_team1", 200, ~S<>))
+      expect(Slax.HttpMock, :put, 1, post_response("org_team2", 200, ~S<>))
+
+      # webhooks
+      expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "1"}>))
+      expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "2"}>))
+
+      result =
+        @subject.new_project(
+          "org_name",
+          "project_name",
+          "access_token",
+          "story_repo",
+          "story_paths",
+          "org_team1,org_team2"
+        )
+
+      assert result[:errors] == %{}
+      assert result[:project_name] == "project_name"
+      assert result[:github_repo] == "project_url"
+      assert result[:slack_channel] == "project_name"
+      assert result[:lintron] == true
+      assert result[:board_checker] == true
+      assert result[:github_org_teams] == true
+      assert result[:resuseable_stories] == true
+
+      assert result[:success] == %{
+               board_checker: "Board Checker Created",
+               github_org_teams: "Github Teams Added",
+               github_repo: "Github Repo Found or Created: <project_url>",
+               lintron: "Lintron Created",
+               project_name: "Project Name Parsed",
+               slack_channel: "Channel Created: <#1|project_name>",
+               resuseable_stories: "Reuseable Stories Created"
+             }
+    end
+
+    test "when creating the github repo fails" do
+      alias Slax.Commands.{GithubCommandsMock, GithubCommands}
+
+      # validate the project_name
+      expect(GithubCommandsMock, :parse_project_name, 1, &GithubCommands.parse_project_name/2)
+
+      # we can't find the repo so it doesn't exist yet
+      expect(
+        Slax.HttpMock,
+        :get,
+        1,
+        response("project_name", 404, ~S<{ "message": "not found" }>)
+      )
+
+      # we fail at creating the repo
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response("project_name", 500, ~S<{ "message": "no repo for you!" }>)
+      )
+
+
+      # we can't create any reusable stories
+      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &failing_create_reusable_stories/5)
+
+      # create slack channel
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response(
+          "project_name",
+          200,
+          ~S<{ "ok": true, "channel": { "id": "1", "name": "project_name" } }>
+        )
+      )
+
+      result =
+        @subject.new_project(
+          "org_name",
+          "project_name",
+          "access_token",
+          "story_repo",
+          "story_paths",
+          "org_team1,org_team2"
+        )
+
+      assert result[:errors] == %{ github_repo: "no repo for you!"}
+
+      assert result[:project_name] == "project_name"
+      assert result[:github_repo] == nil
+      assert result[:slack_channel] == "project_name"
+      assert result[:lintron] == nil
+      assert result[:board_checker] == nil
+      assert result[:github_org_teams] == nil
+      assert result[:resuseable_stories] == nil
+
+      assert result[:success] == %{
+               project_name: "Project Name Parsed",
+               slack_channel: "Channel Created: <#1|project_name>",
+             }
+    end
+
+    test "when the project name is not valid" do
+      alias Slax.Commands.{GithubCommandsMock, GithubCommands}
+
+      # validate the project_name
+      expect(GithubCommandsMock, :parse_project_name, 1, &GithubCommands.parse_project_name/2)
+
+      # we can't create any reusable stories
+      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &failing_create_reusable_stories/5)
+
+      result =
+        @subject.new_project(
+          "org_name",
+          "$project_name&",
+          "access_token",
+          "story_repo",
+          "story_paths",
+          "org_team1,org_team2"
+        )
+
+      assert result[:errors] == %{ project_name: "Invalid Project Name"}
+      assert result[:project_name] == nil
+      assert result[:github_repo] == nil
+      assert result[:slack_channel] == nil
+      assert result[:lintron] == nil
+      assert result[:board_checker] == nil
+      assert result[:github_org_teams] == nil
+      assert result[:resuseable_stories] == nil
+      assert result[:success] == %{}
+    end
+
+    test "when creating the slack channel fails" do
+      alias Slax.Commands.{GithubCommandsMock, GithubCommands}
+
+      # validate the project_name
+      expect(GithubCommandsMock, :parse_project_name, 1, &GithubCommands.parse_project_name/2)
+
+      # we can't find the repo so it doesn't exist yet
+      expect(
+        Slax.HttpMock,
+        :get,
+        1,
+        response("project_name", 404, ~S<{ "message": "not found" }>)
+      )
+
+      # we create the repo
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response("project_name", 200, ~S<{ "html_url": "project_url" }>)
+      )
+
+      # add all reusable stories from the story_repo
+      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &successful_create_reusable_stories/5)
+
+      # create slack channel
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response(
+          "project_name",
+          400,
+          ~S<{ "error": "no channel" }>
+        )
+      )
+
+      # add the teams push permission to the github repo
+      expect(Slax.HttpMock, :put, 1, post_response("org_team1", 200, ~S<>))
+      expect(Slax.HttpMock, :put, 1, post_response("org_team2", 200, ~S<>))
+
+      # webhooks
+      expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "1"}>))
+      expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "2"}>))
+
+      result =
+        @subject.new_project(
+          "org_name",
+          "project_name",
+          "access_token",
+          "story_repo",
+          "story_paths",
+          "org_team1,org_team2"
+        )
+
+      assert result[:errors] == %{ slack_channel: "no channel" }
+      assert result[:project_name] == "project_name"
+      assert result[:github_repo] == "project_url"
+      assert result[:slack_channel] == nil
+      assert result[:lintron] == true
+      assert result[:board_checker] == true
+      assert result[:github_org_teams] == true
+      assert result[:resuseable_stories] == true
+      assert result[:success] == %{
+        resuseable_stories: "Reuseable Stories Created",
+        board_checker: "Board Checker Created",
+        github_org_teams: "Github Teams Added",
+        github_repo: "Github Repo Found or Created: <project_url>",
+        lintron: "Lintron Created",
+        project_name: "Project Name Parsed"
+      }
+    end
+
+    test "adding the org teams fails" do
+      alias Slax.Commands.{GithubCommandsMock, GithubCommands}
+
+      # validate the project_name
+      expect(GithubCommandsMock, :parse_project_name, 1, &GithubCommands.parse_project_name/2)
+
+      # we can't find the repo so it doesn't exist yet
+      expect(
+        Slax.HttpMock,
+        :get,
+        1,
+        response("project_name", 404, ~S<{ "message": "not found" }>)
+      )
+
+      # we create the repo
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response("project_name", 200, ~S<{ "html_url": "project_url" }>)
+      )
+
+      # add all reusable stories from the story_repo
+      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &successful_create_reusable_stories/5)
+
+      # create slack channel
+      expect(
+        Slax.HttpMock,
+        :post,
+        1,
+        post_response(
+          "project_name",
+          200,
+          ~S<{ "ok": true, "channel": { "id": "1", "name": "project_name" } }>
+        )
+      )
+
+      # add the teams push permission to the github repo
+      expect(Slax.HttpMock, :put, 1, post_response("org_team1", 400, ~S<{ "message": "you done goofed" }>))
+      expect(Slax.HttpMock, :put, 1, post_response("org_team2", 400, ~S<{ "message": "you done goofed" }>))
+
+      # webhooks
+      expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "1"}>))
+      expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "2"}>))
+
+      result =
+        @subject.new_project(
+          "org_name",
+          "project_name",
+          "access_token",
+          "story_repo",
+          "story_paths",
+          "org_team1,org_team2"
+        )
+
+      assert result[:errors] == %{ github_org_teams: "org_team1: you done goofed\norg_team2: you done goofed" }
+      assert result[:project_name] == "project_name"
+      assert result[:github_repo] == "project_url"
+      assert result[:slack_channel] == "project_name"
+      assert result[:lintron] == true
+      assert result[:board_checker] == true
+      assert result[:github_org_teams] == nil
+      assert result[:resuseable_stories] == true
+      assert result[:success] == %{
+        resuseable_stories: "Reuseable Stories Created",
+        slack_channel: "Channel Created: <#1|project_name>",
+        board_checker: "Board Checker Created",
+        github_repo: "Github Repo Found or Created: <project_url>",
+        lintron: "Lintron Created",
+        project_name: "Project Name Parsed"
+      }
+    end
+  end
+end

--- a/test/slax/commands/project_test.exs
+++ b/test/slax/commands/project_test.exs
@@ -28,13 +28,13 @@ defmodule Slax.Commands.NewProjectTest do
     end
   end
 
-  def successful_create_reusable_stories(results, _,_,_,_) do
+  def successful_create_reusable_stories(results, _, _, _, _) do
     results
     |> put_in([:resuseable_stories], true)
     |> put_in([:success, :resuseable_stories], "Reuseable Stories Created")
   end
 
-  def failing_create_reusable_stories(results, _,_,_,_), do: results
+  def failing_create_reusable_stories(results, _, _, _, _), do: results
 
   describe "new_project/6" do
     test "when all args are valid and all requests work and the repo hasn't been created yet" do
@@ -60,7 +60,12 @@ defmodule Slax.Commands.NewProjectTest do
       )
 
       # add all reusable stories from the story_repo
-      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &successful_create_reusable_stories/5)
+      expect(
+        Slax.Commands.GithubCommandsMock,
+        :create_reusable_stories,
+        1,
+        &successful_create_reusable_stories/5
+      )
 
       # create slack channel
       expect(
@@ -134,9 +139,13 @@ defmodule Slax.Commands.NewProjectTest do
         post_response("project_name", 500, ~S<{ "message": "no repo for you!" }>)
       )
 
-
       # we can't create any reusable stories
-      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &failing_create_reusable_stories/5)
+      expect(
+        Slax.Commands.GithubCommandsMock,
+        :create_reusable_stories,
+        1,
+        &failing_create_reusable_stories/5
+      )
 
       # create slack channel
       expect(
@@ -160,7 +169,7 @@ defmodule Slax.Commands.NewProjectTest do
           "org_team1,org_team2"
         )
 
-      assert result[:errors] == %{ github_repo: "no repo for you!"}
+      assert result[:errors] == %{github_repo: "no repo for you!"}
 
       assert result[:project_name] == "project_name"
       assert result[:github_repo] == nil
@@ -172,7 +181,7 @@ defmodule Slax.Commands.NewProjectTest do
 
       assert result[:success] == %{
                project_name: "Project Name Parsed",
-               slack_channel: "Channel Created: <#1|project_name>",
+               slack_channel: "Channel Created: <#1|project_name>"
              }
     end
 
@@ -183,7 +192,12 @@ defmodule Slax.Commands.NewProjectTest do
       expect(GithubCommandsMock, :parse_project_name, 1, &GithubCommands.parse_project_name/2)
 
       # we can't create any reusable stories
-      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &failing_create_reusable_stories/5)
+      expect(
+        Slax.Commands.GithubCommandsMock,
+        :create_reusable_stories,
+        1,
+        &failing_create_reusable_stories/5
+      )
 
       result =
         @subject.new_project(
@@ -195,7 +209,7 @@ defmodule Slax.Commands.NewProjectTest do
           "org_team1,org_team2"
         )
 
-      assert result[:errors] == %{ project_name: "Invalid Project Name"}
+      assert result[:errors] == %{project_name: "Invalid Project Name"}
       assert result[:project_name] == nil
       assert result[:github_repo] == nil
       assert result[:slack_channel] == nil
@@ -229,7 +243,12 @@ defmodule Slax.Commands.NewProjectTest do
       )
 
       # add all reusable stories from the story_repo
-      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &successful_create_reusable_stories/5)
+      expect(
+        Slax.Commands.GithubCommandsMock,
+        :create_reusable_stories,
+        1,
+        &successful_create_reusable_stories/5
+      )
 
       # create slack channel
       expect(
@@ -261,7 +280,7 @@ defmodule Slax.Commands.NewProjectTest do
           "org_team1,org_team2"
         )
 
-      assert result[:errors] == %{ slack_channel: "no channel" }
+      assert result[:errors] == %{slack_channel: "no channel"}
       assert result[:project_name] == "project_name"
       assert result[:github_repo] == "project_url"
       assert result[:slack_channel] == nil
@@ -269,14 +288,15 @@ defmodule Slax.Commands.NewProjectTest do
       assert result[:board_checker] == true
       assert result[:github_org_teams] == true
       assert result[:resuseable_stories] == true
+
       assert result[:success] == %{
-        resuseable_stories: "Reuseable Stories Created",
-        board_checker: "Board Checker Created",
-        github_org_teams: "Github Teams Added",
-        github_repo: "Github Repo Found or Created: <project_url>",
-        lintron: "Lintron Created",
-        project_name: "Project Name Parsed"
-      }
+               resuseable_stories: "Reuseable Stories Created",
+               board_checker: "Board Checker Created",
+               github_org_teams: "Github Teams Added",
+               github_repo: "Github Repo Found or Created: <project_url>",
+               lintron: "Lintron Created",
+               project_name: "Project Name Parsed"
+             }
     end
 
     test "adding the org teams fails" do
@@ -302,7 +322,12 @@ defmodule Slax.Commands.NewProjectTest do
       )
 
       # add all reusable stories from the story_repo
-      expect(Slax.Commands.GithubCommandsMock, :create_reusable_stories, 1, &successful_create_reusable_stories/5)
+      expect(
+        Slax.Commands.GithubCommandsMock,
+        :create_reusable_stories,
+        1,
+        &successful_create_reusable_stories/5
+      )
 
       # create slack channel
       expect(
@@ -317,8 +342,19 @@ defmodule Slax.Commands.NewProjectTest do
       )
 
       # add the teams push permission to the github repo
-      expect(Slax.HttpMock, :put, 1, post_response("org_team1", 400, ~S<{ "message": "you done goofed" }>))
-      expect(Slax.HttpMock, :put, 1, post_response("org_team2", 400, ~S<{ "message": "you done goofed" }>))
+      expect(
+        Slax.HttpMock,
+        :put,
+        1,
+        post_response("org_team1", 400, ~S<{ "message": "you done goofed" }>)
+      )
+
+      expect(
+        Slax.HttpMock,
+        :put,
+        1,
+        post_response("org_team2", 400, ~S<{ "message": "you done goofed" }>)
+      )
 
       # webhooks
       expect(Slax.HttpMock, :post, 1, post_response("project_name", 200, ~S<{ "id": "1"}>))
@@ -334,7 +370,10 @@ defmodule Slax.Commands.NewProjectTest do
           "org_team1,org_team2"
         )
 
-      assert result[:errors] == %{ github_org_teams: "org_team1: you done goofed\norg_team2: you done goofed" }
+      assert result[:errors] == %{
+               github_org_teams: "org_team1: you done goofed\norg_team2: you done goofed"
+             }
+
       assert result[:project_name] == "project_name"
       assert result[:github_repo] == "project_url"
       assert result[:slack_channel] == "project_name"
@@ -342,14 +381,15 @@ defmodule Slax.Commands.NewProjectTest do
       assert result[:board_checker] == true
       assert result[:github_org_teams] == nil
       assert result[:resuseable_stories] == true
+
       assert result[:success] == %{
-        resuseable_stories: "Reuseable Stories Created",
-        slack_channel: "Channel Created: <#1|project_name>",
-        board_checker: "Board Checker Created",
-        github_repo: "Github Repo Found or Created: <project_url>",
-        lintron: "Lintron Created",
-        project_name: "Project Name Parsed"
-      }
+               resuseable_stories: "Reuseable Stories Created",
+               slack_channel: "Channel Created: <#1|project_name>",
+               board_checker: "Board Checker Created",
+               github_repo: "Github Repo Found or Created: <project_url>",
+               lintron: "Lintron Created",
+               project_name: "Project Name Parsed"
+             }
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,5 @@
 Mox.defmock(Slax.HttpMock, for: Slax.Http.Behaviour)
 Mox.defmock(Slax.Commands.GithubCommandsMock, for: Slax.Commands.GithubCommands.Behaviour)
-Slax.Command.GithubCommandMock
 ExUnit.configure(exclude: [skip: true])
 ExUnit.start()
 Application.ensure_all_started(:bypass)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 Mox.defmock(Slax.HttpMock, for: Slax.Http.Behaviour)
+Mox.defmock(Slax.Commands.GithubCommandsMock, for: Slax.Commands.GithubCommands.Behaviour)
+Slax.Command.GithubCommandMock
 ExUnit.configure(exclude: [skip: true])
 ExUnit.start()
 Application.ensure_all_started(:bypass)


### PR DESCRIPTION
Still WIP

Connects to #48 increases code coverage for creating a new project!
Since I have another PR open for increasing code coverage for the `GithubCommands` module I made a mock for that module.

This doesn't yet cover all the paths in project creation, still need to cover when creating web-hooks fail.

It definitely feels a little iffy to be specifying this amount of Mox expectations in each test. If there is another pattern that would work here I am all ears!