### PR TITLE
Handle redirects for renamed repos and opt-in to blockerbot

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-iex -S mix phx.server
+iex -S mix

--- a/lib/slax/projects/project_channel.ex
+++ b/lib/slax/projects/project_channel.ex
@@ -8,6 +8,7 @@ defmodule Slax.ProjectChannel do
     belongs_to(:project, Slax.Project)
     field(:channel_name, :string)
     field(:webhook_token, :string)
+    field(:blockerbot_on, :boolean)
 
     timestamps()
   end

--- a/lib/slax/projects/project_repos.ex
+++ b/lib/slax/projects/project_repos.ex
@@ -4,15 +4,15 @@ defmodule Slax.ProjectRepos do
   alias Slax.{ProjectRepo, ProjectChannel}
 
 
-  def get_repos() do
-  ProjectRepo
+  def get_blockerbot_repos() do
+    ProjectRepo
     |> join(:left, [pr], pc in ProjectChannel, on: pr.project_id == pc.project_id)
+    |> where([pr, pc], pc.blockerbot_on)
     |> select([pr, pc], %{
       repo_name: pr.repo_name,
       org_name: pr.org_name,
       channel_name: pc.channel_name
     })
     |> Repo.all()
-    end
-
+  end
 end

--- a/lib/slax/scheduler.ex
+++ b/lib/slax/scheduler.ex
@@ -13,7 +13,6 @@ defmodule Slax.Scheduler do
 
     project_repos
     |> Enum.each(fn repo ->
-      IO.inspect repo
       send_repo_to_channel(repo.org_name, repo.repo_name, repo.channel_name)
     end)
   end

--- a/lib/slax/scheduler.ex
+++ b/lib/slax/scheduler.ex
@@ -9,10 +9,11 @@ defmodule Slax.Scheduler do
   alias Slax.Commands.{Latency}
 
   def start() do
-    project_repos = ProjectRepos.get_repos()
+    project_repos = ProjectRepos.get_blockerbot_repos()
 
     project_repos
     |> Enum.each(fn repo ->
+      IO.inspect repo
       send_repo_to_channel(repo.org_name, repo.repo_name, repo.channel_name)
     end)
   end
@@ -27,7 +28,7 @@ defmodule Slax.Scheduler do
 
     Slack.post_message_to_channel(%{
       text: formatted_response,
-      channel_name: "#" <> channel_name
+      channel_name: channel_name
     })
   end
 end

--- a/lib/slax/slack.ex
+++ b/lib/slax/slack.ex
@@ -85,10 +85,18 @@ defmodule Slax.Slack do
         channel: channel_name
       )
 
-    Http.post(
+    {:ok, response} = Http.post(
       "#{api_url()}/chat.postMessage",
       request,
       "Content-Type": "application/x-www-form-urlencoded"
     )
+
+    IO.inspect response
+    case response do
+      %{body: %{"ok" => false, "error" => error}} ->
+        IO.puts "Error for #{channel_name}: #{error}"
+      _ ->
+        :ok
+    end
   end
 end

--- a/lib/slax/slack.ex
+++ b/lib/slax/slack.ex
@@ -91,7 +91,6 @@ defmodule Slax.Slack do
       "Content-Type": "application/x-www-form-urlencoded"
     )
 
-    IO.inspect response
     case response do
       %{body: %{"ok" => false, "error" => error}} ->
         IO.puts "Error for #{channel_name}: #{error}"

--- a/priv/repo/migrations/20190215192101_database.exs
+++ b/priv/repo/migrations/20190215192101_database.exs
@@ -51,6 +51,7 @@ defmodule Slax.Repo.Migrations.Database do
       add(:created_at, :utc_datetime, null: false)
       add(:updated_at, :utc_datetime, null: false)
       add(:webhook_token, :string)
+      add(:blockerbot_on, :boolean)
     end
 
     create_if_not_exists(

--- a/test/slax/project_repos_test.exs
+++ b/test/slax/project_repos_test.exs
@@ -5,7 +5,7 @@ defmodule Slax.ProjectRepos.Test do
   setup do
     project = insert(:project)
     project_repo = insert(:project_repo, project: project)
-    project_channel = insert(:project_channel, project: project)
+    project_channel = insert(:project_channel, project: project, blockerbot_on: true)
 
     # load associations
     project = Projects.get_project_for_channel(project_channel.channel_name)
@@ -14,17 +14,17 @@ defmodule Slax.ProjectRepos.Test do
   end
 
   describe "get all repos for blockerbot" do
-    test "get_repos/0 with a single repo" do
-      [repo] = ProjectRepos.get_repos()
+    test "get_blockerbot_repos/0 with a single repo" do
+      [repo] = ProjectRepos.get_blockerbot_repos()
 
       assert repo.org_name == "milivanili"
       assert repo.repo_name == "girl u know its true"
       assert repo.channel_name == "testchannel"
     end
 
-    test "get_repos/0 with multiple repos", %{project: project} do
+    test "get_blockerbot_repos/0 with multiple repos", %{project: project} do
       _repo2 = insert(:project_repo, project: project, repo_name: "second one")
-      repos = ProjectRepos.get_repos()
+      repos = ProjectRepos.get_blockerbot_repos()
 
       assert length(repos) == 2
     end

--- a/test/slax/slack_test.exs
+++ b/test/slax/slack_test.exs
@@ -93,15 +93,10 @@ defmodule Slax.Slack.Test do
         {:ok, %HTTPoison.Response{status_code: 200, body: ~s<{"ok": true}>}}
       end)
 
-      assert {:ok,
-              %{
-                status_code: 200,
-                body: %{"ok" => true}
-              }} =
-               Slack.post_message_to_channel(%{
-                 text: "test message",
-                 channel_name: "#channel"
-               })
+      assert :ok == Slack.post_message_to_channel(%{
+          text: "test message",
+          channel_name: "#channel"
+      })
     end
   end
 end


### PR DESCRIPTION
Fixes two issues with Blockerbot:

- Handles when a repo is renamed in GitHub (which causes a redirect)
- Allows Blockerbot to be turned off for certain channels