### PR TITLE
Config fix

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,8 +24,7 @@ config :phoenix, :stacktrace_depth, 20
 config :slax, Slax.Repo,
   database: "slax_dev",
   hostname: "localhost",
-  port: 5432,
-  pool: Ecto.Adapters.SQL.Sandbox
+  port: 5432
 
 if File.exists?(Path.join([__DIR__, "dev.secret.exs"])) do
   import_config "dev.secret.exs"

--- a/lib/slax_web/websocket_listener.ex
+++ b/lib/slax_web/websocket_listener.ex
@@ -66,7 +66,6 @@ defmodule SlaxWeb.WebsocketListener do
          "envelope_id" => envelope_id,
          "payload" => %{"event" => event}
        }) do
-    Logger.info(event)
     Issue.handle_event(event)
 
     with {:ok, response} <- Jason.encode(%{envelope_id: envelope_id}) do


### PR DESCRIPTION
Removed pool from dev config to prevent confusing errors when used with genserver
Removed a logger that was causing confusion in the prod logs