### PR TITLE
Update the name of the modals

### DIFF
--- a/lib/slax_web/websockets/token.ex
+++ b/lib/slax_web/websockets/token.ex
@@ -123,7 +123,7 @@ defmodule SlaxWeb.Token do
       },
       title: %{
         type: "plain_text",
-        text: "Example Modal"
+        text: "Token Modal"
       },
       blocks: [
         %{
@@ -222,7 +222,7 @@ defmodule SlaxWeb.Token do
       },
       title: %{
         type: "plain_text",
-        text: "Example Modal"
+        text: "Repo Modal"
       },
       blocks: [
         %{


### PR DESCRIPTION
`/token` modals were still named `Example Modal`, gave them descriptive names