### PR TITLE
Fix: Put API Params in URL

### DIFF
--- a/lib/slax/slack.ex
+++ b/lib/slax/slack.ex
@@ -223,9 +223,7 @@ defmodule Slax.Slack do
   def get_channels(%{trigger_id: trigger_id}) do
     response =
       Http.get(
-        "#{api_url()}/conversations.list",
-        exclude_archived: true,
-        limit: 999,
+        "#{api_url()}/conversations.list?exclude_archived=true&limit=999",
         "Content-Type": "application/json",
         Authorization: "Bearer #{api_token()}"
       )


### PR DESCRIPTION
Put params in url to increase the limit and reject archived channels

Per an API tester on Slack:
![Screen Shot 2023-12-11 at 18 38 16 PM](https://github.com/revelrylabs/slax/assets/91507958/44e60f65-88a6-413c-87ce-9fee2f25e878)