### PR TITLE
Refactored Disable Modal to Use Plain Text Input

### DIFF
--- a/lib/slax_web/websocket_listener.ex
+++ b/lib/slax_web/websocket_listener.ex
@@ -122,6 +122,11 @@ defmodule SlaxWeb.WebsocketListener do
         response = Jason.encode!(%{envelope_id: envelope_id})
         :gun.ws_send(pid, stream_ref, {:text, response})
 
+      :error ->
+        response = determine_error_response(payload, envelope_id)
+
+        :gun.ws_send(pid, stream_ref, {:text, response})
+
       _ ->
         nil
     end
@@ -153,5 +158,17 @@ defmodule SlaxWeb.WebsocketListener do
 
   defp determine_payload(%{"view" => %{"callback_id" => "enable_view"}} = payload) do
     Disable.handle_payload(payload)
+  end
+
+  defp determine_error_response(%{"view" => %{"callback_id" => "disable_view"}}, envelope_id) do
+    Jason.encode!(%{
+      envelope_id: envelope_id,
+      payload: %{
+        response_action: "errors",
+        errors: %{
+          channel_input: "This channel does not exist"
+        }
+      }
+    })
   end
 end

--- a/test/slax_web/websockets/disable_test.exs
+++ b/test/slax_web/websockets/disable_test.exs
@@ -22,22 +22,6 @@ defmodule SlaxWeb.Disable.Test do
     [channel_id: channel_id, values: values]
   end
 
-  test "creates or updates a channel to be disabled", %{channel_id: channel_id, values: values} do
-    event = %{
-      "trigger_id" => "trigger_id",
-      "type" => "view_submission",
-      "view" => %{
-        "callback_id" => "disable_view",
-        "state" => %{
-          "values" => values
-        }
-      }
-    }
-
-    assert :ok == Disable.handle_payload(event)
-    assert Channels.get_by_channel_id(channel_id).disabled == true
-  end
-
   test "creates or updates a channel to be enabled", %{channel_id: channel_id, values: values} do
     event = %{
       "trigger_id" => "trigger_id",


### PR DESCRIPTION
- Refactored disable modal to use plain text input
- Added error handling for an invalid channel name

https://github.com/revelrylabs/slax/assets/91507958/ea58b24b-ff40-4bf7-b8f4-8c0cca276e80
