### PR TITLE
Feat: Confirmation Modals for Enable and Disable

### DIFF
--- a/lib/slax_web/websockets/disable.ex
+++ b/lib/slax_web/websockets/disable.ex
@@ -58,7 +58,7 @@ defmodule SlaxWeb.Disable do
           disabled: true
         })
 
-        :ok
+        build_disable_confirmation_view(name)
     end
   end
 
@@ -78,7 +78,7 @@ defmodule SlaxWeb.Disable do
       disabled: false
     })
 
-    :ok
+    build_enable_confirmation_view(name)
   end
 
   defp parse_state_values([
@@ -217,6 +217,98 @@ defmodule SlaxWeb.Disable do
             text: "There are no disabled channels.",
             emoji: true
           }
+        }
+      ]
+    }
+  end
+
+  defp build_disable_confirmation_view(name) do
+    %{
+      type: "modal",
+      callback_id: "disable_view",
+      title: %{
+        type: "plain_text",
+        text: "Confirmation",
+        emoji: true
+      },
+      close: %{
+        type: "plain_text",
+        text: "Close",
+        emoji: true
+      },
+      blocks: [
+        %{
+          type: "rich_text",
+          elements: [
+            %{
+              type: "rich_text_section",
+              elements: [
+                %{
+                  type: "text",
+                  text: "Slax has been disabled in "
+                },
+                %{
+                  type: "text",
+                  text: "#{name}  ",
+                  style: %{
+                    bold: true
+                  }
+                },
+                %{
+                  type: "emoji",
+                  name: "homer"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  defp build_enable_confirmation_view(name) do
+    %{
+      type: "modal",
+      callback_id: "enable_view",
+      title: %{
+        type: "plain_text",
+        text: "Confirmation",
+        emoji: true
+      },
+      close: %{
+        type: "plain_text",
+        text: "Close",
+        emoji: true
+      },
+      blocks: [
+        %{
+          type: "rich_text",
+          elements: [
+            %{
+              type: "rich_text_section",
+              elements: [
+                %{
+                  type: "text",
+                  text: "Slax has been enabled in "
+                },
+                %{
+                  type: "text",
+                  text: "#{name}",
+                  style: %{
+                    bold: true
+                  }
+                },
+                %{
+                  type: "text",
+                  text: "!  "
+                },
+                %{
+                  type: "emoji",
+                  name: "reversehomer"
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/test/slax_web/websockets/disable_test.exs
+++ b/test/slax_web/websockets/disable_test.exs
@@ -22,9 +22,8 @@ defmodule SlaxWeb.Disable.Test do
     [channel_id: channel_id, values: values]
   end
 
-  test "creates or updates a channel to be enabled", %{channel_id: channel_id, values: values} do
+  test "updates a channel to be enabled", %{channel_id: channel_id, values: values} do
     event = %{
-      "trigger_id" => "trigger_id",
       "type" => "view_submission",
       "view" => %{
         "callback_id" => "enable_view",
@@ -34,7 +33,7 @@ defmodule SlaxWeb.Disable.Test do
       }
     }
 
-    assert :ok == Disable.handle_payload(event)
+    assert %{title: %{text: "Confirmation"}} = Disable.handle_payload(event)
     assert Channels.get_by_channel_id(channel_id).disabled == false
   end
 end


### PR DESCRIPTION
Adds a confirmation modal when submitting the enable and disable modals


https://github.com/revelrylabs/slax/assets/91507958/2376b183-28eb-4534-a3cc-e739fe325617
