### PR TITLE
Chore // added ability to be used on private channels

### DIFF
--- a/lib/slax/slack.ex
+++ b/lib/slax/slack.ex
@@ -223,7 +223,7 @@ defmodule Slax.Slack do
   def get_channels(%{trigger_id: trigger_id}) do
     response =
       Http.get(
-        "#{api_url()}/conversations.list?exclude_archived=true&limit=999",
+        "#{api_url()}/conversations.list?exclude_archived=true&limit=999&types=public_channel,private_channel",
         "Content-Type": "application/json",
         Authorization: "Bearer #{api_token()}"
       )

--- a/lib/slax_web/websockets/default_repo.ex
+++ b/lib/slax_web/websockets/default_repo.ex
@@ -68,13 +68,18 @@ defmodule SlaxWeb.DefaultRepo do
           type: "input",
           block_id: "channel",
           element: %{
-            type: "channels_select",
+            type: "multi_conversations_select",
             placeholder: %{
               type: "plain_text",
               text: "Select channel",
               emoji: true
             },
-            action_id: "channels_select_action"
+            action_id: "channels_select_action",
+            filter: %{
+              include: ["public", "private"],
+              exclude_external_shared_channels: true,
+              exclude_bot_users: true
+            }
           },
           label: %{
             type: "plain_text",

--- a/slack-manifest.yml
+++ b/slack-manifest.yml
@@ -35,6 +35,8 @@ oauth_config:
       - chat:write.public
       - commands
       - channels:read
+      - groups:read # for private channels
+      - groups:history # for private channels
 settings:
   event_subscriptions:
     user_events:


### PR DESCRIPTION
### Overview

Once we merge this, we'll have to reinstall the app to the workspace 👍 

Currently, Slax can't be used on private channels. This adds that functionality

- Adds `types=public_channel,private_channel` so we can retrieve these channels and information about them (ids, etc)
- Replaces `channels_select` (public only) with `multi_conversations_select` and filters so we still only get channels, not other conversation types
- Adds two permissions: 
  - groups:read - can access channel information (for multi_conversations_select)
  -  groups:history - so Slax will trigger when something like `example_repo_4_slax#1` is used