### PR TITLE
add org clause to project_repos query

### DIFF
--- a/lib/slax/github.ex
+++ b/lib/slax/github.ex
@@ -2,7 +2,6 @@ defmodule Slax.Github do
   @moduledoc """
   Functions for working with the Github API
   """
-
   alias Slax.Http
   alias Slax.Http.Error
   alias Slax.ProjectRepos
@@ -507,7 +506,7 @@ defmodule Slax.Github do
   """
   def load_issue(repo_and_issue) do
     with {org, repo, issue} <- parse_repo_org_issue(repo_and_issue),
-         {token, warning_message} <- retrieve_token(repo),
+         {token, warning_message} <- retrieve_token(repo, org),
          client <- Tentacat.Client.new(%{access_token: token}),
          {200, issue, _http_response} <- Issues.find(client, org, repo, issue) do
       {:ok, issue, warning_message}
@@ -531,7 +530,7 @@ defmodule Slax.Github do
 
   def load_pr(repo_and_pr) do
     with {org, repo, pr} <- parse_repo_org_issue(repo_and_pr),
-         {token, warning_message} <- retrieve_token(repo),
+         {token, warning_message} <- retrieve_token(repo, org),
          client <- Tentacat.Client.new(%{access_token: token}),
          {200, pr, _http_response} <- Prs.find(client, org, repo, pr) do
       {:ok, pr, warning_message}
@@ -566,8 +565,8 @@ defmodule Slax.Github do
     end)
   end
 
-  defp retrieve_token(repo) do
-    case ProjectRepos.get_by_repo(repo) do
+  defp retrieve_token(repo, org) do
+    case ProjectRepos.get_by_repo(repo, org) do
       %{token: token} when not is_nil(token) ->
         {token, ""}
 

--- a/lib/slax/poker.ex
+++ b/lib/slax/poker.ex
@@ -72,7 +72,7 @@ defmodule Slax.Poker do
     {org, repo, issue} = Github.parse_repo_org_issue(round.issue)
 
     client =
-      case ProjectRepos.get_by_repo(repo) do
+      case ProjectRepos.get_by_repo(repo, org) do
         %{token: token} when not is_nil(token) ->
           Tentacat.Client.new(%{access_token: token})
 

--- a/lib/slax/projects/project_repos.ex
+++ b/lib/slax/projects/project_repos.ex
@@ -72,8 +72,8 @@ defmodule Slax.ProjectRepos do
     |> Repo.all()
   end
 
-  def get_by_repo(repo_name) do
-    Repo.get_by(ProjectRepo, repo_name: repo_name)
+  def get_by_repo(repo_name, org_name) do
+    Repo.get_by(ProjectRepo, repo_name: repo_name, org_name: org_name)
   end
 
   def list_needs_reminder_message() do

--- a/test/slax/github_test.exs
+++ b/test/slax/github_test.exs
@@ -545,15 +545,15 @@ defmodule Slax.Github.Test do
 
   def load_issue_setup(context) do
     project = insert(:project)
-    insert(:project_repo, project: project, token: "success", repo_name: "success")
-    insert(:project_repo, project: project, token: "failure", repo_name: "failure")
-    insert(:project_repo, project: project, token: nil, repo_name: "nil")
+    insert(:project_repo, project: project, token: "success", repo_name: "success", org_name: "owner")
+    insert(:project_repo, project: project, token: "failure", repo_name: "failure", org_name: "owner")
+    insert(:project_repo, project: project, token: nil, repo_name: "nil", org_name: "owner")
 
     params = %{
-      repo_and_issue_success: "success/1",
-      repo_and_issue_failure: "failure/1",
-      repo_and_issue_nil: "nil/1",
-      repo_and_issue_na: "na/1"
+      repo_and_issue_success: "owner/success/1",
+      repo_and_issue_failure: "owner/failure/1",
+      repo_and_issue_nil: "owner/nil/1",
+      repo_and_issue_na: "owner/na/1"
     }
 
     {:ok, context |> Map.put(:params, params)}

--- a/test/slax/github_test.exs
+++ b/test/slax/github_test.exs
@@ -545,9 +545,27 @@ defmodule Slax.Github.Test do
 
   def load_issue_setup(context) do
     project = insert(:project)
-    insert(:project_repo, project: project, token: "success", repo_name: "success", org_name: "owner")
-    insert(:project_repo, project: project, token: "failure", repo_name: "failure", org_name: "owner")
-    insert(:project_repo, project: project, token: nil, repo_name: "nil", org_name: "owner")
+
+    insert(:project_repo,
+      project: project,
+      token: "success",
+      repo_name: "success",
+      org_name: "owner"
+    )
+
+    insert(:project_repo,
+      project: project,
+      token: "failure",
+      repo_name: "failure",
+      org_name: "owner"
+    )
+
+    insert(:project_repo,
+      project: project,
+      token: nil,
+      repo_name: "nil",
+      org_name: "owner"
+    )
 
     params = %{
       repo_and_issue_success: "owner/success/1",


### PR DESCRIPTION
fixes #450

Adds a parameter to check not only repo name but also org name to prevent the error shown in the issue.