### PR TITLE
make repo and org query case insensitive

### DIFF
--- a/lib/slax/github.ex
+++ b/lib/slax/github.ex
@@ -566,7 +566,7 @@ defmodule Slax.Github do
   end
 
   defp retrieve_token(repo, org) do
-    case ProjectRepos.get_by_repo(repo, org) do
+    case ProjectRepos.get_by_repo_and_org(repo, org) do
       %{token: token} when not is_nil(token) ->
         {token, ""}
 

--- a/lib/slax/poker.ex
+++ b/lib/slax/poker.ex
@@ -72,7 +72,7 @@ defmodule Slax.Poker do
     {org, repo, issue} = Github.parse_repo_org_issue(round.issue)
 
     client =
-      case ProjectRepos.get_by_repo(repo, org) do
+      case ProjectRepos.get_by_repo_and_org(repo, org) do
         %{token: token} when not is_nil(token) ->
           Tentacat.Client.new(%{access_token: token})
 

--- a/lib/slax/projects/project_repos.ex
+++ b/lib/slax/projects/project_repos.ex
@@ -72,8 +72,19 @@ defmodule Slax.ProjectRepos do
     |> Repo.all()
   end
 
-  def get_by_repo(repo_name, org_name) do
-    Repo.get_by(ProjectRepo, repo_name: repo_name, org_name: org_name)
+  def get_by_repo_and_org(repo_name, org_name) do
+    lower_repo_name = String.downcase(repo_name)
+    lower_org_name = String.downcase(org_name)
+
+    query =
+      from(
+        p in ProjectRepo,
+        where:
+          fragment("lower(?)", p.repo_name) == ^lower_repo_name and
+            fragment("lower(?)", p.org_name) == ^lower_org_name
+      )
+
+    Repo.one(query)
   end
 
   def list_needs_reminder_message() do

--- a/test/slax/project_repos_test.exs
+++ b/test/slax/project_repos_test.exs
@@ -36,4 +36,12 @@ defmodule Slax.ProjectRepos.Test do
       assert length(repos_with_token) == 1
     end
   end
+
+  describe "get one by repo_name and org_name" do
+    test "get_by_repo_and_org/2" do
+      repo = ProjectRepos.get_by_repo_and_org("girl u know its TRUE", "miLIVAnili")
+      assert repo.org_name == "milivanili"
+      assert repo.repo_name == "girl u know its true"
+    end
+  end
 end


### PR DESCRIPTION
address #450 

refactors the query used to make case insensitive comparison and renames function to get_by_repo_and_org