### PR TITLE
Chore // Removes warning from `String.slice`

### DIFF
--- a/lib/slax_web/websockets/issue.ex
+++ b/lib/slax_web/websockets/issue.ex
@@ -60,7 +60,7 @@ defmodule SlaxWeb.Issue do
       _ ->
         org_name = default_repo.org_name
         repo_name = default_repo.repo_name
-        issue_number = String.slice(issue_number, 1..-1)
+        issue_number = String.slice(issue_number, 1..-1//1)
         load_pr_or_issue_from_github("#{org_name}/#{repo_name}##{issue_number}")
     end
   end


### PR DESCRIPTION
### Overview

After borking slax this morning (I think due to something completely different) I noticed this warning in the logs and thought I might fix it (seeing as I bumped this app up to 1.16 in the first place 5 months ago 😬 )

From the docs: [[Enum] Deprecate passing a range with negative step on Enum.slice/2, give first..last//1 instead](https://github.com/elixir-lang/elixir/releases/tag/v1.16.0)

