### PR TITLE
fix(#483): Async processing to prevent delayed ack

### DIFF
--- a/lib/slax.ex
+++ b/lib/slax.ex
@@ -11,7 +11,8 @@ defmodule Slax do
         Slax.Repo,
         SlaxWeb.Endpoint,
         Slax.Scheduler,
-        {Oban, Application.fetch_env!(:slax, Oban)}
+        {Oban, Application.fetch_env!(:slax, Oban)},
+        {Task.Supervisor, name: Slax.TaskSupervisor}
       ] ++ optional_children()
 
     opts = [strategy: :one_for_one, name: Slax.Supervisor]

--- a/lib/slax_web/websocket_listener.ex
+++ b/lib/slax_web/websocket_listener.ex
@@ -83,7 +83,9 @@ defmodule SlaxWeb.WebsocketListener do
     channel = Channels.get_by_channel_id(channel)
 
     if is_nil(channel) or !channel.disabled do
-      Issue.handle_event(event)
+      Task.Supervisor.start_child(Slax.TaskSupervisor, fn ->
+        Issue.handle_event(event)
+      end)
 
       case Jason.encode(%{envelope_id: envelope_id}) do
         {:ok, response} -> :gun.ws_send(pid, stream_ref, {:text, response})


### PR DESCRIPTION
connects to: #483 

### Description

Currently, the event handler and the ack sent to slack are in the same process, blocking the ack until the event handler. This change moves event processing into a supervised `Task` for better concurrency.. Events that take longer to process (say, stand-ups with 6+ issue/pr mentions), will not block the ack and trigger a second process.

### Changes
- Adds `TaskSupervisor` to supervision tree
- Moves `Issue.handle_event` into supervised Tasks