### PR TITLE
feat: Issue Lookup - PR slack emojis

### DIFF
--- a/lib/slax_web/websockets/issue.ex
+++ b/lib/slax_web/websockets/issue.ex
@@ -81,12 +81,17 @@ defmodule SlaxWeb.Issue do
   defp load_pr_from_github(repo_and_pr) do
     case Github.load_pr(repo_and_pr) do
       {:ok, pr, warning_message} ->
-        "<#{pr["html_url"]}|#{repo_and_pr}>: [PR] #{pr["title"]} (#{pr["state"]}) #{warning_message}"
+        %{"html_url" => url, "title" => title, "state" => state} = pr
+        "<#{url}|#{repo_and_pr}>: [PR] #{title} #{pr_slack_emoji(state)} #{warning_message}"
 
       {:error, error} ->
         error
     end
   end
+
+  defp pr_slack_emoji("open"), do: ":pr:"
+  defp pr_slack_emoji("closed"), do: ":pr-merged:"
+  defp pr_slack_emoji(state), do: "(#{state})"
 
   def labels_for_issue(issue) do
     column_label =


### PR DESCRIPTION
Just thought it'd be a nice visual cue to see a 🟢 PR Open emoji or a 🟣 PR merged emoji to be able to tell at a glance that a thing is a PR and whether it is open or closed.

Full disclosure I have not actually tested this since the local setup is a bit tedious, but I plan to tomorrow.

Also fully aware that if those specific emojis get deleted from our slack it will not work as intended 😅 