### PR TITLE
fix: post the /poker start issue text in chunks via chat.postMessage

### DIFF
--- a/lib/slax/poker.ex
+++ b/lib/slax/poker.ex
@@ -3,10 +3,6 @@ defmodule Slax.Poker do
   use Slax.Context
   alias Slax.{Github, Poker.Round, ProjectRepos}
 
-  # Slack closes the socket-mode connection (1009) when a frame exceeds 20 KiB,
-  # so the issue body cannot be echoed in full.
-  @max_body_chars 3_000
-
   def start_round(channel_name, issue) do
     repo_and_issue =
       Regex.replace(~r".*/repos/(\S+)/(\S+)/issues/(\d+)$", issue["url"], "\\1/\\2/\\3")
@@ -26,7 +22,7 @@ defmodule Slax.Poker do
       ---
       #{pr}#{issue["number"]}: #{issue["title"]} (#{labels})
       ---
-      #{truncate_body(issue["body"])}
+      #{issue["body"]}
       #{issue["html_url"]}
       This issue has #{issue["comments"]} #{Inflex.inflect("comment", issue["comments"])}
 
@@ -38,17 +34,6 @@ defmodule Slax.Poker do
     """
 
     {:ok, response}
-  end
-
-  @doc false
-  def truncate_body(nil), do: ""
-
-  def truncate_body(body) do
-    if String.length(body) <= @max_body_chars do
-      body
-    else
-      String.slice(body, 0, @max_body_chars) <> "\n_[body truncated, see the issue link]_"
-    end
   end
 
   @doc """

--- a/lib/slax/poker.ex
+++ b/lib/slax/poker.ex
@@ -3,6 +3,10 @@ defmodule Slax.Poker do
   use Slax.Context
   alias Slax.{Github, Poker.Round, ProjectRepos}
 
+  # Slack closes the socket-mode connection (1009) when a frame exceeds 20 KiB,
+  # so the issue body cannot be echoed in full.
+  @max_body_chars 3_000
+
   def start_round(channel_name, issue) do
     repo_and_issue =
       Regex.replace(~r".*/repos/(\S+)/(\S+)/issues/(\d+)$", issue["url"], "\\1/\\2/\\3")
@@ -22,7 +26,7 @@ defmodule Slax.Poker do
       ---
       #{pr}#{issue["number"]}: #{issue["title"]} (#{labels})
       ---
-      #{issue["body"]}
+      #{truncate_body(issue["body"])}
       #{issue["html_url"]}
       This issue has #{issue["comments"]} #{Inflex.inflect("comment", issue["comments"])}
 
@@ -34,6 +38,17 @@ defmodule Slax.Poker do
     """
 
     {:ok, response}
+  end
+
+  @doc false
+  def truncate_body(nil), do: ""
+
+  def truncate_body(body) do
+    if String.length(body) <= @max_body_chars do
+      body
+    else
+      String.slice(body, 0, @max_body_chars) <> "\n_[body truncated, see the issue link]_"
+    end
   end
 
   @doc """

--- a/lib/slax/slack.ex
+++ b/lib/slax/slack.ex
@@ -108,6 +108,48 @@ defmodule Slax.Slack do
     end
   end
 
+  # Slack collapses messages past ~4,000 characters and drops anything over
+  # 40,000, so long text goes out as a series of messages.
+  @max_message_chars 4_000
+
+  def post_long_message_to_channel(text, channel_name \\ default_channel()) do
+    text
+    |> chunk_message()
+    |> Enum.each(&post_message_to_channel(&1, channel_name))
+  end
+
+  @doc false
+  def chunk_message(""), do: []
+
+  def chunk_message(text) do
+    text
+    |> String.split("\n")
+    |> Enum.flat_map(&split_long_line/1)
+    |> Enum.reduce([], fn
+      line, [] ->
+        [line]
+
+      line, [current | rest] ->
+        if String.length(current) + String.length(line) + 1 <= @max_message_chars do
+          [current <> "\n" <> line | rest]
+        else
+          [line, current | rest]
+        end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp split_long_line(line) do
+    if String.length(line) <= @max_message_chars do
+      [line]
+    else
+      line
+      |> String.graphemes()
+      |> Enum.chunk_every(@max_message_chars)
+      |> Enum.map(&Enum.join/1)
+    end
+  end
+
   @doc """
     Posts text to a given channel and thread
   """

--- a/lib/slax_web/websockets/poker.ex
+++ b/lib/slax_web/websockets/poker.ex
@@ -26,10 +26,13 @@ defmodule SlaxWeb.Poker do
     with {:ok, issue, warning_message} <- Github.load_issue(repo_and_issue),
          {:ok, _} <- Poker.end_current_round_for_channel(channel_name),
          {:ok, response} <- Poker.start_round(channel_name, issue) do
-      %{
-        response_type: "in_channel",
-        text: response <> warning_message
-      }
+      # The socket-mode ack frame is capped at 20 KiB and must go out within
+      # 3 seconds, so the issue text is posted separately and asynchronously.
+      Task.Supervisor.start_child(Slax.TaskSupervisor, fn ->
+        Slack.post_long_message_to_channel(response <> warning_message, channel_name)
+      end)
+
+      %{}
     else
       {:error, message} ->
         %{text: message}

--- a/test/slax/poker_test.exs
+++ b/test/slax/poker_test.exs
@@ -3,27 +3,10 @@ defmodule Slax.PokerTest do
 
   alias Slax.Poker
 
-  @slack_max_frame_bytes 20_480
-
-  describe "truncate_body/1" do
-    test "returns an empty string for a missing body" do
-      assert Poker.truncate_body(nil) == ""
-    end
-
-    test "leaves short bodies untouched" do
-      assert Poker.truncate_body("short body") == "short body"
-    end
-
-    test "truncates long bodies and appends a notice" do
-      result = Poker.truncate_body(String.duplicate("x", 25_000))
-
-      assert String.length(result) < 3_100
-      assert String.ends_with?(result, "_[body truncated, see the issue link]_")
-    end
-  end
-
   describe "start_round/2" do
-    test "keeps the response inside Slack's socket-mode frame limit" do
+    test "keeps the full issue body in the response" do
+      body = String.duplicate("line of spec text\n", 1_500)
+
       issue = %{
         "url" => "https://api.github.com/repos/org/repo/issues/1",
         "html_url" => "https://github.com/org/repo/issues/1",
@@ -31,20 +14,13 @@ defmodule Slax.PokerTest do
         "title" => "Huge issue",
         "labels" => [],
         "comments" => 0,
-        "body" => String.duplicate("line of spec text\n", 1_500)
+        "body" => body
       }
 
       {:ok, response} = Poker.start_round("tech-poker", issue)
 
-      frame =
-        Jason.encode!(%{
-          envelope_id: "abc",
-          payload: %{response_type: "in_channel", text: response}
-        })
-
-      assert byte_size(frame) < @slack_max_frame_bytes
       assert response =~ "Planning poker for org/repo/1"
-      assert response =~ "_[body truncated, see the issue link]_"
+      assert String.contains?(response, body)
     end
   end
 end

--- a/test/slax/poker_test.exs
+++ b/test/slax/poker_test.exs
@@ -1,0 +1,50 @@
+defmodule Slax.PokerTest do
+  use Slax.ModelCase
+
+  alias Slax.Poker
+
+  @slack_max_frame_bytes 20_480
+
+  describe "truncate_body/1" do
+    test "returns an empty string for a missing body" do
+      assert Poker.truncate_body(nil) == ""
+    end
+
+    test "leaves short bodies untouched" do
+      assert Poker.truncate_body("short body") == "short body"
+    end
+
+    test "truncates long bodies and appends a notice" do
+      result = Poker.truncate_body(String.duplicate("x", 25_000))
+
+      assert String.length(result) < 3_100
+      assert String.ends_with?(result, "_[body truncated, see the issue link]_")
+    end
+  end
+
+  describe "start_round/2" do
+    test "keeps the response inside Slack's socket-mode frame limit" do
+      issue = %{
+        "url" => "https://api.github.com/repos/org/repo/issues/1",
+        "html_url" => "https://github.com/org/repo/issues/1",
+        "number" => 1,
+        "title" => "Huge issue",
+        "labels" => [],
+        "comments" => 0,
+        "body" => String.duplicate("line of spec text\n", 1_500)
+      }
+
+      {:ok, response} = Poker.start_round("tech-poker", issue)
+
+      frame =
+        Jason.encode!(%{
+          envelope_id: "abc",
+          payload: %{response_type: "in_channel", text: response}
+        })
+
+      assert byte_size(frame) < @slack_max_frame_bytes
+      assert response =~ "Planning poker for org/repo/1"
+      assert response =~ "_[body truncated, see the issue link]_"
+    end
+  end
+end

--- a/test/slax/slack_test.exs
+++ b/test/slax/slack_test.exs
@@ -151,4 +151,44 @@ defmodule Slax.Slack.Test do
       assert :ok == Slack.update_modal(%{trigger_id: "trigger_id", view: %{}, view_id: "view_id"})
     end
   end
+
+  describe "chunk_message/1" do
+    test "returns short text as a single message" do
+      assert Slack.chunk_message("hello\nworld") == ["hello\nworld"]
+    end
+
+    test "splits on line breaks, keeps every message within the limit, loses nothing" do
+      text = String.duplicate("line of spec text\n", 1_500)
+      chunks = Slack.chunk_message(text)
+
+      assert length(chunks) > 1
+      assert Enum.all?(chunks, &(String.length(&1) <= 4_000))
+      assert Enum.join(chunks, "\n") == text
+    end
+
+    test "hard-splits a single line longer than the limit" do
+      chunks = Slack.chunk_message(String.duplicate("x", 9_000))
+
+      assert Enum.map(chunks, &String.length/1) == [4_000, 4_000, 1_000]
+    end
+  end
+
+  describe "post_long_message_to_channel/2" do
+    test "posts every chunk to the channel in order" do
+      text = String.duplicate("line of spec text\n", 1_500)
+      expected = Slack.chunk_message(text)
+      {:ok, posted} = Agent.start_link(fn -> [] end)
+
+      expect(Slax.HttpMock, :post, length(expected), fn _, body, _, _ ->
+        Agent.update(posted, &[URI.decode_query(body) | &1])
+        {:ok, %HTTPoison.Response{status_code: 200, body: ~s<{"ok": true}>}}
+      end)
+
+      Slack.post_long_message_to_channel(text, "tech-poker")
+
+      requests = posted |> Agent.get(& &1) |> Enum.reverse()
+      assert Enum.map(requests, & &1["text"]) == expected
+      assert Enum.all?(requests, &(&1["channel"] == "tech-poker"))
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Slack's socket-mode server closes the connection with code 1009 (`Max frame length of 20480 has been exceeded.`) when a client frame is larger than 20 KiB. `/poker start` put the full GitHub issue body inside the slash-command acknowledgement frame, so any issue with a body near 20 KB dropped the socket. Slack then redelivered the command on each reconnect, and the bot appeared down for a couple of minutes per attempt.

Seen in production today against an issue with a 20,458-character body:

```
GenServer #PID<0.86090.0> terminating
** (FunctionClauseError) no function clause matching in SlaxWeb.WebsocketListener.handle_info/2
    lib/slax_web/websocket_listener.ex:57: ... {:close, 1009, "Max frame length of 20480 has been exceeded."}
```

## Change

- `/poker start` now acks with an empty payload (as `reveal` and `decide` already do) and posts the full text with `chat.postMessage` from a supervised task, so the ack never carries the body and always beats Slack's 3-second deadline.
- New `Slack.post_long_message_to_channel/2` splits text on line breaks into messages of at most 4,000 characters (Slack's recommended ceiling; the hard limit is 40,000) and posts them in order. A single line longer than that is hard-split. Nothing is dropped.
- Tests cover the chunking (limit, order, no loss, hard split), the posting (one request per chunk, in order, right channel), and `start_round/2` keeping the whole body.

The first commit truncated the body instead; the second replaces that with chunked posting.

## Behaviour change

The bot's reply is a normal bot post instead of an `in_channel` slash-command response, so the invoking `/poker start ...` line is no longer echoed to the channel (same as `reveal` and `decide` today).

## Test

`mix test`: 1 property, 98 tests, 0 failures.